### PR TITLE
Current job class may inherit directly from ActiveJob::Base or from ApplicationJob 

### DIFF
--- a/lib/sidekiq/enqueuer/worker/trigger.rb
+++ b/lib/sidekiq/enqueuer/worker/trigger.rb
@@ -43,7 +43,7 @@ module Sidekiq
         end
 
         def active_job?
-          job.superclass == ::ActiveJob::Base
+          job <= ::ActiveJob::Base
         end
       end
     end


### PR DESCRIPTION
ApplicationJob (which inherits from ActiveJob::Base) is a new pattern in Rails5 to consolidate common code for jobs.  Theoretically there could be other intermediate job classes.  This will check the entire inheritance hierarchy.  If you think this could be a valuable addition to your library, please accept my PR.  