### PR TITLE
fix enqueue button not work on firefox browser

### DIFF
--- a/lib/sidekiq/enqueuer/views/index.erb
+++ b/lib/sidekiq/enqueuer/views/index.erb
@@ -14,11 +14,9 @@
         <td width="40%"><%= job.name %></td>
         <td width="40%"><%= job.params.map(&:name).join(', ') %></td>
         <td width="20%">
-          <button class="btn btn-danger btn-xs">
-            <a href="<%= root_path %>enqueuer/<%= job.name %>" style="color: white;">
-              Enqueue Form
-            </a>
-          </button>
+          <a class="btn btn-danger btn-xs" href="<%= root_path %>enqueuer/<%= job.name %>" style="color: white;">
+            Enqueue Form
+          </a>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
Hi,

enquere button is not working on firefox browser.
The structure containing the `a` element in the` button` element does not seem to conform to HTML standards.

```html
/*perhaps this is not conform html standard*/
<button>
  <a> Enqueue </a>
</button>
```

So, I think that firefox is not working as intended.