### PR TITLE
Creates option to define queue in enqueue form. 

### DIFF
--- a/lib/sidekiq/enqueuer.rb
+++ b/lib/sidekiq/enqueuer.rb
@@ -23,7 +23,10 @@ module Sidekiq
       def all_jobs
         included_jobs = defined?(@all_jobs) ? @all_jobs : configuration.all_jobs
         included_jobs.each_with_object([]) do |job_klass, acc|
-          acc << Worker::Instance.new(job_klass, configuration.enqueue_using_async)
+          worker = Worker::Instance.new(job_klass, configuration.enqueue_using_async)
+          if worker.instance_method.present?
+            acc << worker
+          end
         end
       end
     end

--- a/lib/sidekiq/enqueuer/views/new.erb
+++ b/lib/sidekiq/enqueuer/views/new.erb
@@ -20,6 +20,12 @@
           <input class="form-control" name="perform[<%= param.name %>]" />
         </div>
       <% end %>
+
+      <div class="form-group">
+        <label for="job_queue">Queue</label>
+        <input class="form-control" name="job_queue" value="<%= @job_default_queue %>" />
+      </div>
+
     </div>
   </div>
 

--- a/lib/sidekiq/enqueuer/web_extension/helper.rb
+++ b/lib/sidekiq/enqueuer/web_extension/helper.rb
@@ -12,6 +12,16 @@ module Sidekiq
             job_klass.job == job_class_name || job_klass.job.to_s == job_class_name || job_klass.name == job_class_name
           end
         end
+
+        def deduce_queue(enqueuer_worker_instance)
+
+          if enqueuer_worker_instance&.job.present?
+            enqueuer_worker_instance.job.sidekiq_options['queue']&.to_s
+          else
+            'default'
+          end
+        end
+
       end
     end
   end

--- a/lib/sidekiq/enqueuer/web_extension/loader.rb
+++ b/lib/sidekiq/enqueuer/web_extension/loader.rb
@@ -13,16 +13,16 @@ module Sidekiq
 
           app.get '/enqueuer/:job_class_name' do
             @job = find_job_by_class_name(params[:job_class_name])
+            @job_default_queue = deduce_queue(@job)
             render(:erb, File.read(File.join(view_path, 'new.erb')))
           end
 
           app.post '/enqueuer' do
             job = find_job_by_class_name(params[:job_class_name])
-
             if job
               requested_params = get_params_by_action('perform', job)
-              job.trigger(requested_params) if params['submit'] == 'Enqueue'
-              job.trigger_in(params['enqueue_in'], requested_params) if params['submit'] == 'Schedule'
+              job.trigger(requested_params, params['job_queue']) if params['submit'] == 'Enqueue'
+              job.trigger_in(params['enqueue_in'], requested_params, params['job_queue']) if params['submit'] == 'Schedule'
             end
             redirect "#{root_path}enqueuer"
           end

--- a/lib/sidekiq/enqueuer/worker/instance.rb
+++ b/lib/sidekiq/enqueuer/worker/instance.rb
@@ -42,7 +42,7 @@ module Sidekiq
         end
 
         def worker_params
-          job.instance_method(instance_method).parameters
+          instance_method.present? ? job.instance_method(instance_method).parameters : []          
         end
       end
     end

--- a/lib/sidekiq/enqueuer/worker/instance.rb
+++ b/lib/sidekiq/enqueuer/worker/instance.rb
@@ -11,12 +11,12 @@ module Sidekiq
           @params              = deduce_params
         end
 
-        def trigger(input_params)
-          trigger_job(input_params).enqueue
+        def trigger(input_params, queue)
+          trigger_job(input_params, queue).enqueue
         end
 
-        def trigger_in(seconds, input_params)
-          trigger_job(input_params).enqueue_in(seconds.to_s.to_i.seconds)
+        def trigger_in(seconds, input_params, queue)
+          trigger_job(input_params, queue).enqueue_in(seconds.to_s.to_i.seconds)
         end
 
         def name
@@ -25,8 +25,8 @@ module Sidekiq
 
         private
 
-        def trigger_job(input_params)
-          Sidekiq::Enqueuer::Worker::Trigger.new(job, input_params)
+        def trigger_job(input_params, queue)
+          Sidekiq::Enqueuer::Worker::Trigger.new(job, input_params, queue)
         end
 
         # TODO: what if two of this methods exist? which one to pick to figure out params?

--- a/lib/sidekiq/enqueuer/worker/trigger.rb
+++ b/lib/sidekiq/enqueuer/worker/trigger.rb
@@ -6,9 +6,9 @@ module Sidekiq
 
         attr_reader :job, :queue, :args_with_values
 
-        def initialize(job, input_param_hash)
+        def initialize(job, input_param_hash, queue)
           @job = job
-          @queue = deduce_queue
+          @queue = queue
           @args_with_values = input_param_hash
         end
 
@@ -33,10 +33,6 @@ module Sidekiq
         end
 
         private
-
-        def deduce_queue
-          job.respond_to?(:sidekiq_options) ? job.sidekiq_options['queue'].to_s : 'default'
-        end
 
         def sidekiq_job?
           job.included_modules.include? ::Sidekiq::Worker


### PR DESCRIPTION
- Ive added an option in the enqueue form so that the user can specify there in which queue he wants to enqueue the job. By default, the gem will use the deduce_queue method to automatically populate it, so if the user has defined it in the job it will already have that value.
- Ive also added a check to only add jobs to the job list when they have a perform method defined. It was throwing me an error because I hade a "Base" worker without a defined perform method that would be defined by the child classes.
Let me know what you think of this changes